### PR TITLE
feat: download audit reporting and analytics dashboard

### DIFF
--- a/odp/ui/admin/templates/base.html
+++ b/odp/ui/admin/templates/base.html
@@ -3,59 +3,59 @@
 {% from 'page.j2' import nav_logo, nav_title, nav_menu, nav_dropdown, footer %}
 
 {% block web_title %}
-ODP Admin
+    ODP Admin
 {% endblock %}
 
 {% block header %}
-<nav class="navbar navbar-expand-lg bg-dark navbar-dark p-3">
-    <div class="container-fluid">
-        <div class="navbar-nav justify-content-start flex-grow-evenly">
-            {{ nav_logo() }}
-        </div>
-        <div class="d-flex flex-column navbar-nav justify-content-center align-items-center">
-            {{ nav_title() }}
-            {% if current_user.is_authenticated %}
-            <div class="d-flex flex-row">
-                {{ nav_dropdown('Metadata Management', request.blueprint, dark=true,
-                records='Records',
-                collections='Collections',
-                providers='Providers',
-                _='',
-                catalogs='Catalogues',
-                schemas='Schemas',
-                tags='Tags',
-                vocabularies='Vocabularies'
-                ) }}
-                {{ nav_dropdown('Access Control', request.blueprint, dark=true,
-                clients='Clients',
-                roles='Roles',
-                users='Users'
-                ) }}
-                {{ nav_dropdown('Reports', request.blueprint, dark=true,
-                downloads='Downloads'
-                ) }}
+    <nav class="navbar navbar-expand-lg bg-dark navbar-dark p-3">
+        <div class="container-fluid">
+            <div class="navbar-nav justify-content-start flex-grow-evenly">
+                {{ nav_logo() }}
             </div>
-            {% endif %}
+            <div class="d-flex flex-column navbar-nav justify-content-center align-items-center">
+                {{ nav_title() }}
+                {% if current_user.is_authenticated %}
+                    <div class="d-flex flex-row">
+                        {{ nav_dropdown('Metadata Management', request.blueprint, dark=true,
+                            records='Records',
+                            collections='Collections',
+                            providers='Providers',
+                            _='',
+                            catalogs='Catalogues',
+                            schemas='Schemas',
+                            tags='Tags',
+                            vocabularies='Vocabularies'
+                        ) }}
+                        {{ nav_dropdown('Access Control', request.blueprint, dark=true,
+                            clients='Clients',
+                            roles='Roles',
+                            users='Users'
+                        ) }}
+                        {{ nav_dropdown('Reports', request.blueprint, dark=true,
+                            downloads='Downloads'
+                        ) }}
+                    </div>
+                {% endif %}
+            </div>
+            <div class="navbar-nav justify-content-end flex-grow-evenly">
+                {{ nav_menu(current_user) }}
+            </div>
         </div>
-        <div class="navbar-nav justify-content-end flex-grow-evenly">
-            {{ nav_menu(current_user) }}
-        </div>
-    </div>
-</nav>
+    </nav>
 {% endblock %}
 
 {% block footer %}
-{{ footer(
-repos=['odp-server', 'odp-admin', 'odp-core', 'odp-ui']
-) }}
+    {{ footer(
+        repos=['odp-server', 'odp-admin', 'odp-core', 'odp-ui']
+    ) }}
 {% endblock %}
 
 {% block styles %}
-{{ super() }}
-{{ bootswatch_spacelab_css() }}
+    {{ super() }}
+    {{ bootswatch_spacelab_css() }}
 {% endblock %}
 
 {% block scripts %}
-{{ super() }}
-{{ jquery_js() }}
+    {{ super() }}
+    {{ jquery_js() }}
 {% endblock %}

--- a/odp/ui/admin/templates/base.html
+++ b/odp/ui/admin/templates/base.html
@@ -3,56 +3,59 @@
 {% from 'page.j2' import nav_logo, nav_title, nav_menu, nav_dropdown, footer %}
 
 {% block web_title %}
-    ODP Admin
+ODP Admin
 {% endblock %}
 
 {% block header %}
-    <nav class="navbar navbar-expand-lg bg-dark navbar-dark p-3">
-        <div class="container-fluid">
-            <div class="navbar-nav justify-content-start flex-grow-evenly">
-                {{ nav_logo() }}
-            </div>
-            <div class="d-flex flex-column navbar-nav justify-content-center align-items-center">
-                {{ nav_title() }}
-                {% if current_user.is_authenticated %}
-                    <div class="d-flex flex-row">
-                        {{ nav_dropdown('Metadata Management', request.blueprint, dark=true,
-                            records='Records',
-                            collections='Collections',
-                            providers='Providers',
-                            _='',
-                            catalogs='Catalogues',
-                            schemas='Schemas',
-                            tags='Tags',
-                            vocabularies='Vocabularies'
-                        ) }}
-                        {{ nav_dropdown('Access Control', request.blueprint, dark=true,
-                            clients='Clients',
-                            roles='Roles',
-                            users='Users'
-                        ) }}
-                    </div>
-                {% endif %}
-            </div>
-            <div class="navbar-nav justify-content-end flex-grow-evenly">
-                {{ nav_menu(current_user) }}
-            </div>
+<nav class="navbar navbar-expand-lg bg-dark navbar-dark p-3">
+    <div class="container-fluid">
+        <div class="navbar-nav justify-content-start flex-grow-evenly">
+            {{ nav_logo() }}
         </div>
-    </nav>
+        <div class="d-flex flex-column navbar-nav justify-content-center align-items-center">
+            {{ nav_title() }}
+            {% if current_user.is_authenticated %}
+            <div class="d-flex flex-row">
+                {{ nav_dropdown('Metadata Management', request.blueprint, dark=true,
+                records='Records',
+                collections='Collections',
+                providers='Providers',
+                _='',
+                catalogs='Catalogues',
+                schemas='Schemas',
+                tags='Tags',
+                vocabularies='Vocabularies'
+                ) }}
+                {{ nav_dropdown('Access Control', request.blueprint, dark=true,
+                clients='Clients',
+                roles='Roles',
+                users='Users'
+                ) }}
+                {{ nav_dropdown('Reports', request.blueprint, dark=true,
+                downloads='Downloads'
+                ) }}
+            </div>
+            {% endif %}
+        </div>
+        <div class="navbar-nav justify-content-end flex-grow-evenly">
+            {{ nav_menu(current_user) }}
+        </div>
+    </div>
+</nav>
 {% endblock %}
 
 {% block footer %}
-    {{ footer(
-        repos=['odp-server', 'odp-admin', 'odp-core', 'odp-ui']
-    ) }}
+{{ footer(
+repos=['odp-server', 'odp-admin', 'odp-core', 'odp-ui']
+) }}
 {% endblock %}
 
 {% block styles %}
-    {{ super() }}
-    {{ bootswatch_spacelab_css() }}
+{{ super() }}
+{{ bootswatch_spacelab_css() }}
 {% endblock %}
 
 {% block scripts %}
-    {{ super() }}
-    {{ jquery_js() }}
+{{ super() }}
+{{ jquery_js() }}
 {% endblock %}

--- a/odp/ui/admin/templates/download_analytics.html
+++ b/odp/ui/admin/templates/download_analytics.html
@@ -1,0 +1,202 @@
+{% extends 'base.html' %}
+
+{% block web_title %}
+    {{ super() }} |
+    {% block heading %}
+        Download Analytics
+    {% endblock %}
+{% endblock %}
+
+{% block content %}
+    <div class="container-fluid">
+        <h2 class="mb-4">Download Analytics Dashboard</h2>
+
+        <!-- Date Range Filter -->
+        <form class="row g-3 mb-4 p-3 bg-light rounded" method="get">
+            <div class="col-md-3">
+                <label for="start_date" class="form-label">Start Date</label>
+                <input type="date" class="form-control" id="start_date" name="start_date" value="{{ start_date }}">
+            </div>
+            <div class="col-md-3">
+                <label for="end_date" class="form-label">End Date</label>
+                <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
+            </div>
+            <div class="col-md-3 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary w-100">Update</button>
+            </div>
+            <div class="col-md-3 d-flex align-items-end">
+                <a href="{{ url_for('downloads.index') }}" class="btn btn-secondary w-100">Back to Logs</a>
+            </div>
+        </form>
+
+        {% if error %}
+            <div class="alert alert-danger">
+                <strong>Error:</strong> {{ error }}
+            </div>
+        {% else %}
+            <!-- Summary Cards -->
+            <div class="row mb-4">
+                <div class="col-md-3">
+                    <div class="card text-white bg-primary">
+                        <div class="card-body">
+                            <h5 class="card-title">Total Downloads</h5>
+                            <p class="card-text" style="font-size: 2rem; font-weight: bold;">
+                                {{ stats.get('total_downloads', 0)|default('0') }}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="card text-white bg-success">
+                        <div class="card-body">
+                            <h5 class="card-title">Unique Users</h5>
+                            <p class="card-text" style="font-size: 2rem; font-weight: bold;">
+                                {{ stats.get('unique_users', 0)|default('0') }}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="card text-white bg-info">
+                        <div class="card-body">
+                            <h5 class="card-title">Total Data Volume</h5>
+                            <p class="card-text" style="font-size: 1.3rem; font-weight: bold;">
+                                {% set volume = stats.get('total_data_volume', 0) %}
+                                {% if volume > 1073741824 %}
+                                    {{ (volume / 1073741824)|round(2) }} GB
+                                {% elif volume > 1048576 %}
+                                    {{ (volume / 1048576)|round(2) }} MB
+                                {% else %}
+                                    {{ volume }} bytes
+                                {% endif %}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="card text-white bg-warning">
+                        <div class="card-body">
+                            <h5 class="card-title">Success Rate</h5>
+                            <p class="card-text" style="font-size: 2rem; font-weight: bold;">
+                                {% set total = stats.get('total_downloads', 0) %}
+                                {% set successful = stats.get('successful_downloads', 0) %}
+                                {% if total > 0 %}
+                                    {{ ((successful / total) * 100)|round(1) }}%
+                                {% else %}
+                                    N/A
+                                {% endif %}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Download Breakdown -->
+            <div class="row mb-4">
+                <div class="col-md-6">
+                    <div class="card">
+                        <div class="card-header bg-dark text-white">
+                            <h5 class="card-title mb-0">Downloads by Type</h5>
+                        </div>
+                        <div class="card-body">
+                            {% set by_type = stats.get('downloads_by_type', {}) %}
+                            {% if by_type %}
+                                <table class="table table-sm">
+                                    <thead>
+                                        <tr>
+                                            <th>Type</th>
+                                            <th class="text-end">Count</th>
+                                            <th class="text-end">Percentage</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% set total_downloads = stats.get('total_downloads', 0) %}
+                                        {% for type_name, count in by_type.items() %}
+                                            <tr>
+                                                <td>
+                                                    {% if type_name == 'single_record' %}
+                                                        <span class="badge bg-primary">Single Record</span>
+                                                    {% elif type_name == 'zip_bundle' %}
+                                                        <span class="badge bg-warning text-dark">ZIP Bundle</span>
+                                                    {% else %}
+                                                        {{ type_name }}
+                                                    {% endif %}
+                                                </td>
+                                                <td class="text-end"><strong>{{ count }}</strong></td>
+                                                <td class="text-end">
+                                                    {% if total_downloads > 0 %}
+                                                        {{ ((count / total_downloads) * 100)|round(1) }}%
+                                                    {% else %}
+                                                        0%
+                                                    {% endif %}
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% else %}
+                                <p class="text-muted">No data available</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-md-6">
+                    <div class="card">
+                        <div class="card-header bg-dark text-white">
+                            <h5 class="card-title mb-0">Download Status</h5>
+                        </div>
+                        <div class="card-body">
+                            <table class="table table-sm">
+                                <thead>
+                                    <tr>
+                                        <th>Status</th>
+                                        <th class="text-end">Count</th>
+                                        <th class="text-end">Percentage</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><span class="badge bg-success">Successful</span></td>
+                                        <td class="text-end"><strong>{{ stats.get('successful_downloads', 0) }}</strong></td>
+                                        <td class="text-end">
+                                            {% set total_downloads = stats.get('total_downloads', 0) %}
+                                            {% set successful = stats.get('successful_downloads', 0) %}
+                                            {% if total_downloads > 0 %}
+                                                {{ ((successful / total_downloads) * 100)|round(1) }}%
+                                            {% else %}
+                                                0%
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><span class="badge bg-danger">Failed</span></td>
+                                        <td class="text-end"><strong>{{ stats.get('failed_downloads', 0) }}</strong></td>
+                                        <td class="text-end">
+                                            {% set total_downloads = stats.get('total_downloads', 0) %}
+                                            {% set failed = stats.get('failed_downloads', 0) %}
+                                            {% if total_downloads > 0 %}
+                                                {{ ((failed / total_downloads) * 100)|round(1) }}%
+                                            {% else %}
+                                                0%
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Additional Info -->
+            <div class="alert alert-info">
+                <strong>Date Range:</strong> {{ start_date }} to {{ end_date }}
+            </div>
+
+        {% endif %}
+    </div>
+
+    <!-- Optional: Add Chart.js library for more advanced visualizations -->
+    <!-- This would require adding chart.js script and implementing JavaScript to render charts -->
+{% endblock %}

--- a/odp/ui/admin/templates/download_analytics.html
+++ b/odp/ui/admin/templates/download_analytics.html
@@ -56,23 +56,23 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-md-3">
-                    <div class="card text-white bg-info">
-                        <div class="card-body">
-                            <h5 class="card-title">Total Data Volume</h5>
-                            <p class="card-text" style="font-size: 1.3rem; font-weight: bold;">
-                                {% set volume = stats.get('total_data_volume', 0) %}
-                                {% if volume > 1073741824 %}
-                                    {{ (volume / 1073741824)|round(2) }} GB
-                                {% elif volume > 1048576 %}
-                                    {{ (volume / 1048576)|round(2) }} MB
-                                {% else %}
-                                    {{ volume }} bytes
-                                {% endif %}
-                            </p>
-                        </div>
-                    </div>
-                </div>
+<!--                <div class="col-md-3">-->
+<!--                    <div class="card text-white bg-info">-->
+<!--                        <div class="card-body">-->
+<!--                            <h5 class="card-title">Total Data Volume</h5>-->
+<!--                            <p class="card-text" style="font-size: 1.3rem; font-weight: bold;">-->
+<!--                                {% set volume = stats.get('total_data_volume', 0) %}-->
+<!--                                {% if volume > 1073741824 %}-->
+<!--                                    {{ (volume / 1073741824)|round(2) }} GB-->
+<!--                                {% elif volume > 1048576 %}-->
+<!--                                    {{ (volume / 1048576)|round(2) }} MB-->
+<!--                                {% else %}-->
+<!--                                    {{ volume }} bytes-->
+<!--                                {% endif %}-->
+<!--                            </p>-->
+<!--                        </div>-->
+<!--                    </div>-->
+<!--                </div>-->
                 <div class="col-md-3">
                     <div class="card text-white bg-warning">
                         <div class="card-body">
@@ -189,6 +189,170 @@
                 </div>
             </div>
 
+            <!-- Organisations Analytics -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header bg-dark text-white">
+                            <h5 class="card-title mb-0">Downloads by Organisation (Top 20)</h5>
+                        </div>
+                        <div class="card-body">
+                            {% set organisations = stats.get('organisations', []) %}
+                            {% if organisations %}
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-hover">
+                                        <thead>
+                                            <tr>
+                                                <th>Organisation</th>
+                                                <th class="text-end">Downloads</th>
+                                                <th class="text-end">Unique Users</th>
+                                                <th class="text-end">% of Total</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% set total_downloads = stats.get('total_downloads', 0) %}
+                                            {% for org in organisations %}
+                                                <tr>
+                                                    <td><strong>{{ org.name }}</strong></td>
+                                                    <td class="text-end">{{ org.downloads }}</td>
+                                                    <td class="text-end">{{ org.unique_users }}</td>
+                                                    <td class="text-end">
+                                                        {% if total_downloads > 0 %}
+                                                            {{ ((org.downloads / total_downloads) * 100)|round(1) }}%
+                                                        {% else %}
+                                                            0%
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">No organisation data available</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Most Downloaded Records -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header bg-dark text-white">
+                            <h5 class="card-title mb-0">Most Downloaded Records (Top 10)</h5>
+                        </div>
+                        <div class="card-body">
+                            {% set top_records = stats.get('top_records', []) %}
+                            {% if top_records %}
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-hover">
+                                        <thead>
+                                            <tr>
+                                                <th>DOI</th>
+                                                <th class="text-end">Downloads</th>
+                                                <th class="text-end">Unique Users</th>
+                                                <th class="text-end">% of Total</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% set total_downloads = stats.get('total_downloads', 0) %}
+                                            {% for record in top_records %}
+                                                <tr>
+                                                    <td>
+                                                        {% if record.doi %}
+                                                            <a href="{{ config.MIMS_CATALOG_URL }}/{{ record.doi }}" target="_blank" class="text-decoration-none">
+                                                                {{ record.doi }}
+                                                            </a>
+                                                        {% else %}
+                                                            <span class="text-muted">-</span>
+                                                        {% endif %}
+                                                    </td>
+                                                    <td class="text-end"><strong>{{ record.downloads }}</strong></td>
+                                                    <td class="text-end">{{ record.unique_users }}</td>
+                                                    <td class="text-end">
+                                                        {% if total_downloads > 0 %}
+                                                            {{ ((record.downloads / total_downloads) * 100)|round(1) }}%
+                                                        {% else %}
+                                                            0%
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">No record data available</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Daily Downloads Trend -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header bg-dark text-white">
+                            <h5 class="card-title mb-0">Daily Downloads Trend</h5>
+                        </div>
+                        <div class="card-body">
+                            {% set daily = stats.get('daily_downloads', []) %}
+                            {% if daily %}
+                                <div class="table-responsive" style="max-height: 400px; overflow-y: auto;">
+                                    <table class="table table-sm">
+                                        <thead style="position: sticky; top: 0; background: #f8f9fa;">
+                                            <tr>
+                                                <th>Date</th>
+                                                <th class="text-end">Total Downloads</th>
+                                                <th class="text-end">Successful</th>
+                                                <th class="text-end">Failed</th>
+                                                <th class="text-end">Success Rate</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for day in daily %}
+                                                <tr>
+                                                    <td><strong>{{ day.date }}</strong></td>
+                                                    <td class="text-end">{{ day.downloads }}</td>
+                                                    <td class="text-end"><span class="badge bg-success">{{ day.successful }}</span></td>
+                                                    <td class="text-end"><span class="badge bg-danger">{{ day.failed }}</span></td>
+                                                    <td class="text-end">
+                                                        {% if day.downloads > 0 %}
+                                                            {{ ((day.successful / day.downloads) * 100)|round(1) }}%
+                                                        {% else %}
+                                                            N/A
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            {% else %}
+                                <p class="text-muted">No daily data available</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Chart Visualization -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header bg-dark text-white">
+                            <h5 class="card-title mb-0">Downloads Over Time</h5>
+                        </div>
+                        <div class="card-body">
+                            <canvas id="dailyTrendChart" height="80"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Additional Info -->
             <div class="alert alert-info">
                 <strong>Date Range:</strong> {{ start_date }} to {{ end_date }}
@@ -197,6 +361,94 @@
         {% endif %}
     </div>
 
-    <!-- Optional: Add Chart.js library for more advanced visualizations -->
-    <!-- This would require adding chart.js script and implementing JavaScript to render charts -->
+    <!-- Chart.js library for visualizations -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
+    <script>
+        // Initialize daily downloads trend chart
+        document.addEventListener('DOMContentLoaded', function() {
+            const chartCanvas = document.getElementById('dailyTrendChart');
+            if (!chartCanvas) return;
+
+            const dailyData = {{ stats.get('daily_downloads', [])|tojson }};
+            if (dailyData.length === 0) {
+                chartCanvas.parentElement.innerHTML = '<p class="text-muted">No data available for chart</p>';
+                return;
+            }
+
+            const labels = dailyData.map(d => d.date);
+            const downloads = dailyData.map(d => d.downloads);
+            const successful = dailyData.map(d => d.successful);
+            const failed = dailyData.map(d => d.failed);
+
+            new Chart(chartCanvas, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {
+                            label: 'Total Downloads',
+                            data: downloads,
+                            borderColor: '#0d6efd',
+                            backgroundColor: 'rgba(13, 110, 253, 0.1)',
+                            tension: 0.3,
+                            fill: true,
+                            borderWidth: 2
+                        },
+                        {
+                            label: 'Successful',
+                            data: successful,
+                            borderColor: '#198754',
+                            backgroundColor: 'rgba(25, 135, 84, 0.1)',
+                            tension: 0.3,
+                            fill: true,
+                            borderWidth: 2
+                        },
+                        {
+                            label: 'Failed',
+                            data: failed,
+                            borderColor: '#dc3545',
+                            backgroundColor: 'rgba(220, 53, 69, 0.1)',
+                            tension: 0.3,
+                            fill: true,
+                            borderWidth: 2
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {
+                        legend: {
+                            position: 'top',
+                            labels: {
+                                usePointStyle: true,
+                                padding: 15
+                            }
+                        },
+                        title: {
+                            display: false
+                        }
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            ticks: {
+                                stepSize: 1
+                            },
+                            title: {
+                                display: true,
+                                text: 'Number of Downloads'
+                            }
+                        },
+                        x: {
+                            title: {
+                                display: true,
+                                text: 'Date'
+                            }
+                        }
+                    }
+                }
+            });
+        });
+    </script>
 {% endblock %}

--- a/odp/ui/admin/templates/download_analytics.html
+++ b/odp/ui/admin/templates/download_analytics.html
@@ -260,7 +260,7 @@
                                             {% set total_downloads = stats.get('total_downloads', 0) %}
                                             {% for record in top_records %}
                                                 <tr>
-                                                    <td>
+                                                    <td>{{ config.MIMS_CATALOG_URL }}
                                                         {% if record.doi %}
                                                             <a href="{{ config.MIMS_CATALOG_URL }}/{{ record.doi }}" target="_blank" class="text-decoration-none">
                                                                 {{ record.doi }}

--- a/odp/ui/admin/templates/download_analytics.html
+++ b/odp/ui/admin/templates/download_analytics.html
@@ -260,11 +260,20 @@
                                             {% set total_downloads = stats.get('total_downloads', 0) %}
                                             {% for record in top_records %}
                                                 <tr>
-                                                    <td>{{ config.MIMS_CATALOG_URL }}
+                                                    <td>
                                                         {% if record.doi %}
-                                                            <a href="{{ config.MIMS_CATALOG_URL }}/{{ record.doi }}" target="_blank" class="text-decoration-none">
-                                                                {{ record.doi }}
-                                                            </a>
+                                                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+
+                                                                <a href="
+                                                                {% if base.endswith('/catalog') %}
+                                                                    {{ base }}/{{ record.doi }}
+                                                                {% else %}
+                                                                    {{ base }}/catalog/{{ record.doi }}
+                                                                {% endif %}
+                                                                " target="_blank" class="text-decoration-none">
+                                                                    {{ record.doi }}
+                                                                </a>
+
                                                         {% else %}
                                                             <span class="text-muted">-</span>
                                                         {% endif %}

--- a/odp/ui/admin/templates/download_analytics.html
+++ b/odp/ui/admin/templates/download_analytics.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'lib.j2' import chartjs_js %}
 
 {% block web_title %}
     {{ super() }} |
@@ -369,11 +370,12 @@
 
         {% endif %}
     </div>
+{% endblock %}
 
-    <!-- Chart.js library for visualizations -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
+{% block scripts %}
+    {{ super() }}
+    {{ chartjs_js() }}
     <script>
-        // Initialize daily downloads trend chart
         document.addEventListener('DOMContentLoaded', function() {
             const chartCanvas = document.getElementById('dailyTrendChart');
             if (!chartCanvas) return;

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -107,7 +107,8 @@
                                     {% if download.download_type == 'single_record' %}
                                         {% set doi = download.meta.get('doi', '') %}
                                         {% if doi %}
-                                            <a href="{{ config.MIMS_CATALOG_URL }}/{{ doi }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
+                                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+                                            <a href="{% if base.endswith('/catalog') %}{{ base }}/{{ doi }}{% else %}{{ base }}/catalog/{{ doi }}{% endif %}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
                                         {% else %}
                                             -
                                         {% endif %}

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -113,11 +113,11 @@
                                             -
                                         {% endif %}
                                     {% elif download.download_type == 'zip_bundle' %}
-                                        {% set dois = download.meta.get('dois', []) %}
-                                        {% if dois and dois|length > 0 %}
+                                        {% set record_ids = download.meta.get('record_ids', []) %}
+                                        {% if record_ids and record_ids|length > 0 %}
                                             {% set query_parts = [] %}
-                                            {% for doi in dois %}
-                                                {% set _ = query_parts.append('record_id_or_doi_list=' + doi) %}
+                                            {% for record_id in record_ids %}
+                                                {% set _ = query_parts.append('record_id_or_doi_list=' + record_id) %}
                                             {% endfor %}
                                             {% set query = query_parts|join('&') %}
 

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -107,7 +107,7 @@
                                     {% if download.download_type == 'single_record' %}
                                         {% set doi = download.meta.get('doi', '') %}
                                         {% if doi %}
-                                            <a href="http://mims.localhost:2021/catalog/{{ doi }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
+                                            <a href="{{ config.MIMS_CATALOG_URL }}/{{ doi }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
                                         {% else %}
                                             -
                                         {% endif %}
@@ -119,7 +119,7 @@
                                                 {% set _ = query_parts.append('record_id_or_doi_list=' + doi) %}
                                             {% endfor %}
                                             {% set query = query_parts|join('&') %}
-                                            <a href="http://mims.localhost:2021/catalog/subset?{{ query }}&page=1&size=50" target="_blank" class="btn btn-sm btn-outline-warning">View Bundle</a>
+                                            <a href="{{ config.MIMS_CATALOG_URL }}/subset?{{ query }}&page=1&size=50" target="_blank" class="btn btn-sm btn-outline-warning">View Bundle</a>
                                         {% else %}
                                             -
                                         {% endif %}

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -1,195 +1,213 @@
 {% extends 'base.html' %}
 
 {% block web_title %}
-    {{ super() }} |
-    {% block heading %}
-        Download Logs
-    {% endblock %}
+{{ super() }} |
+{% block heading %}
+Download Logs
+{% endblock %}
 {% endblock %}
 
 {% block content %}
-    <div class="container-fluid">
-        <h2 class="mb-4">Download Audit Logs</h2>
+<div class="container-fluid">
+    <h2 class="mb-4">Download Audit Logs</h2>
 
-        <!-- Filter Form -->
-        <form class="row g-3 mb-4 p-3 bg-light rounded" method="get">
-            <div class="col-md-2">
-                <label for="start_date" class="form-label">Start Date</label>
-                <input type="date" class="form-control" id="start_date" name="start_date" value="{{ start_date }}">
-            </div>
-            <div class="col-md-2">
-                <label for="end_date" class="form-label">End Date</label>
-                <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
-            </div>
-            <div class="col-md-2">
-                <label for="email" class="form-label">Email</label>
-                <input type="email" class="form-control" id="email" name="email" value="{{ email }}" placeholder="user@example.com">
-            </div>
-            <div class="col-md-2">
-                <label for="organisation" class="form-label">Organisation</label>
-                <input type="text" class="form-control" id="organisation" name="organisation" value="{{ organisation }}" placeholder="Org name">
-            </div>
-            <div class="col-md-2">
-                <label for="download_type" class="form-label">Download Type</label>
-                <select class="form-control" id="download_type" name="download_type">
-                    <option value="">All Types</option>
-                    <option value="single_record" {% if download_type == 'single_record' %}selected{% endif %}>Single Record</option>
-                    <option value="zip_bundle" {% if download_type == 'zip_bundle' %}selected{% endif %}>ZIP Bundle</option>
-                </select>
-            </div>
-            <div class="col-md-2 d-flex align-items-end">
-                <button type="submit" class="btn btn-primary w-100">Filter</button>
-            </div>
-        </form>
-
-        <!-- Action Buttons -->
-        <div class="mb-3">
-            <a href="{{ url_for('downloads.analytics') }}" class="btn btn-info">View Analytics</a>
-            <a href="{{ url_for('downloads.export_csv', start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}" class="btn btn-success">Export CSV</a>
+    <!-- Filter Form -->
+    <form class="row g-3 mb-4 p-3 bg-light rounded" method="get">
+        <div class="col-md-2">
+            <label for="start_date" class="form-label">Start Date</label>
+            <input type="date" class="form-control" id="start_date" name="start_date" value="{{ start_date }}">
         </div>
-
-        <!-- Results Summary -->
-        <div class="alert alert-info">
-            Showing <strong>{{ downloads|length }}</strong> of <strong>{{ total }}</strong> total downloads
-            {% if start_date or end_date or email or organisation or download_type %}
-                <span class="ms-3">
-                    <a href="{{ url_for('downloads.index') }}" class="alert-link">Clear filters</a>
-                </span>
-            {% endif %}
+        <div class="col-md-2">
+            <label for="end_date" class="form-label">End Date</label>
+            <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
         </div>
+        <div class="col-md-2">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" name="email" value="{{ email }}"
+                   placeholder="user@example.com">
+        </div>
+        <div class="col-md-2">
+            <label for="organisation" class="form-label">Organisation</label>
+            <input type="text" class="form-control" id="organisation" name="organisation" value="{{ organisation }}"
+                   placeholder="Org name">
+        </div>
+        <div class="col-md-2">
+            <label for="download_type" class="form-label">Download Type</label>
+            <select class="form-control" id="download_type" name="download_type">
+                <option value="">All Types</option>
+                <option value="single_record" {% if download_type==
+                'single_record' %}selected{% endif %}>Single Record</option>
+                <option value="zip_bundle" {% if download_type==
+                'zip_bundle' %}selected{% endif %}>ZIP Bundle</option>
+            </select>
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary w-100">Filter</button>
+        </div>
+    </form>
 
-        {% if error %}
-            <div class="alert alert-danger">
-                <strong>Error:</strong> {{ error }}
-            </div>
+    <!-- Action Buttons -->
+    <div class="mb-3">
+        <a href="{{ url_for('downloads.analytics') }}" class="btn btn-info">View Analytics</a>
+        <a href="{{ url_for('downloads.export_csv', start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}"
+           class="btn btn-success">Export CSV</a>
+    </div>
+
+    <!-- Results Summary -->
+    <div class="alert alert-info">
+        Showing <strong>{{ downloads|length }}</strong> of <strong>{{ total }}</strong> total downloads
+        {% if start_date or end_date or email or organisation or download_type %}
+        <span class="ms-3">
+            <a href="{{ url_for('downloads.index') }}" class="alert-link">Clear filters</a>
+        </span>
         {% endif %}
+    </div>
 
-        <!-- Downloads Table -->
-        {% if downloads %}
-            <div class="table-responsive">
-                <table class="table table-striped table-hover table-sm">
-                    <thead class="table-dark">
-                        <tr>
-                            <th>Date/Time</th>
-                            <th>Name</th>
-                            <th>Email</th>
-                            <th>Organisation</th>
-                            <th>Type</th>
-                            <th>Status</th>
-                            <th>Record Link</th>
-                            <th>IP Address</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for download in downloads %}
-                            <tr>
-                                <td>{{ download.timestamp[:19] }}</td>
-                                <td>{{ download.name or '-' }}</td>
-                                <td>{{ download.email or '-' }}</td>
-                                <td>{{ download.organisation or '-' }}</td>
-                                <td>
-                                    {% if download.download_type == 'single_record' %}
-                                        <span class="badge bg-primary">Single Record</span>
-                                    {% elif download.download_type == 'zip_bundle' %}
-                                        <span class="badge bg-warning text-dark">ZIP Bundle</span>
-                                    {% else %}
-                                        <span class="badge bg-secondary">{{ download.download_type or '-' }}</span>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if download.success %}
-                                        <span class="badge bg-success">Success</span>
-                                    {% else %}
-                                        <span class="badge bg-danger">Failed</span>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if download.download_type == 'single_record' %}
-                                        {% set doi = download.meta.get('doi', '') %}
-                                        {% if doi %}
-                                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
-                                            <a href="{% if base.endswith('/catalog') %}{{ base }}/{{ doi }}{% else %}{{ base }}/catalog/{{ doi }}{% endif %}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
-                                        {% else %}
-                                            -
-                                        {% endif %}
-                                    {% elif download.download_type == 'zip_bundle' %}
-                                        {% set record_ids = download.meta.get('record_ids', []) %}
-                                        {% if record_ids and record_ids|length > 0 %}
-                                            {% set query_parts = [] %}
-                                            {% for record_id in record_ids %}
-                                                {% set _ = query_parts.append('record_id_or_doi_list=' + record_id) %}
-                                            {% endfor %}
-                                            {% set query = query_parts|join('&') %}
+    {% if error %}
+    <div class="alert alert-danger">
+        <strong>Error:</strong> {{ error }}
+    </div>
+    {% endif %}
 
-                                                {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+    <!-- Downloads Table -->
+    {% if downloads %}
+    <div class="table-responsive">
+        <table class="table table-striped table-hover table-sm">
+            <thead class="table-dark">
+            <tr>
+                <th>Date/Time</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Organisation</th>
+                <th>Type</th>
+                <th>Status</th>
+                <th>Record Link</th>
+                <th>IP Address</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for download in downloads %}
+            <tr>
+                <td>{{ download.timestamp[:19] }}</td>
+                <td>{{ download.name or '-' }}</td>
+                <td>{{ download.email or '-' }}</td>
+                <td>{{ download.organisation or '-' }}</td>
+                <td>
+                    {% if download.download_type == 'single_record' %}
+                    <span class="badge bg-primary">Single Record</span>
+                    {% elif download.download_type == 'zip_bundle' %}
+                    <span class="badge bg-warning text-dark">ZIP Bundle</span>
+                    {% else %}
+                    <span class="badge bg-secondary">{{ download.download_type or '-' }}</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if download.success %}
+                    <span class="badge bg-success">Success</span>
+                    {% else %}
+                    <span class="badge bg-danger">Failed</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if download.download_type == 'single_record' %}
+                    {% set doi = download.doi %}
+                    {% if doi %}
+                    {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+                    <a href="
+                                                {% if base.endswith('/catalog') %}
+                                                    {{ base }}/{{ doi }}
+                                                {% else %}
+                                                    {{ base }}/catalog/{{ doi }}
+                                                {% endif %}
+                                                " target="_blank" class="btn btn-sm btn-outline-primary">
+                        View Record
+                    </a>
+                    {% else %}
+                    -
+                    {% endif %}
+                    {% elif download.download_type == 'zip_bundle' %}
+                    {% set record_ids = download.record_ids %} {% if record_ids and record_ids|length > 0 %}
+                    {% set query_parts = [] %}
+                    {% for record_id in record_ids %}
+                    {% set _ = query_parts.append('record_id_or_doi_list=' + record_id) %}
+                    {% endfor %}
+                    {% set query = query_parts|join('&') %}
 
-                                                {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+                    {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
 
-                                                <a href="
+                    {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+
+                    <a href="
                                                 {% if base.endswith('/catalog') %}
                                                     {{ base }}/subset?{{ query }}&page=1&size=50
                                                 {% else %}
                                                     {{ base }}/catalog/subset?{{ query }}&page=1&size=50
                                                 {% endif %}
                                                 " target="_blank" class="btn btn-sm btn-outline-warning">
-                                                    View Bundle
-                                                </a>
+                        View Bundle
+                    </a>
 
-                                        {% else %}
-                                            -
-                                        {% endif %}
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                                <td><small>{{ download.ip_address or '-' }}</small></td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
+                    {% else %}
+                    -
+                    {% endif %}
+                    {% else %}
+                    -
+                    {% endif %}
+                </td>
+                <td><small>{{ download.ip_address or '-' }}</small></td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
 
-            <!-- Pagination -->
-            {% if total_pages > 1 %}
-                <nav aria-label="Page navigation">
-                    <ul class="pagination justify-content-center">
-                        {% if page > 1 %}
-                            <li class="page-item">
-                                <a class="page-link" href="{{ url_for('downloads.index', page=1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">First</a>
-                            </li>
-                            <li class="page-item">
-                                <a class="page-link" href="{{ url_for('downloads.index', page=page-1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Previous</a>
-                            </li>
-                        {% endif %}
-
-                        {% for p in range(1, total_pages + 1) %}
-                            {% if p == page %}
-                                <li class="page-item active">
-                                    <span class="page-link">{{ p }}</span>
-                                </li>
-                            {% elif p >= page - 2 and p <= page + 2 %}
-                                <li class="page-item">
-                                    <a class="page-link" href="{{ url_for('downloads.index', page=p, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">{{ p }}</a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-
-                        {% if page < total_pages %}
-                            <li class="page-item">
-                                <a class="page-link" href="{{ url_for('downloads.index', page=page+1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Next</a>
-                            </li>
-                            <li class="page-item">
-                                <a class="page-link" href="{{ url_for('downloads.index', page=total_pages, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Last</a>
-                            </li>
-                        {% endif %}
-                    </ul>
-                </nav>
+    <!-- Pagination -->
+    {% if total_pages > 1 %}
+    <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            {% if page > 1 %}
+            <li class="page-item">
+                <a class="page-link"
+                   href="{{ url_for('downloads.index', page=1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">First</a>
+            </li>
+            <li class="page-item">
+                <a class="page-link"
+                   href="{{ url_for('downloads.index', page=page-1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Previous</a>
+            </li>
             {% endif %}
 
-        {% else %}
-            <div class="alert alert-info">
-                No download records found matching your criteria.
-            </div>
-        {% endif %}
+            {% for p in range(1, total_pages + 1) %}
+            {% if p == page %}
+            <li class="page-item active">
+                <span class="page-link">{{ p }}</span>
+            </li>
+            {% elif p >= page - 2 and p <= page + 2 %}
+            <li class="page-item">
+                <a class="page-link"
+                   href="{{ url_for('downloads.index', page=p, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">{{
+                    p }}</a>
+            </li>
+            {% endif %}
+            {% endfor %}
+
+            {% if page < total_pages %}
+            <li class="page-item">
+                <a class="page-link"
+                   href="{{ url_for('downloads.index', page=page+1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Next</a>
+            </li>
+            <li class="page-item">
+                <a class="page-link"
+                   href="{{ url_for('downloads.index', page=total_pages, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Last</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
+
+    {% else %}
+    <div class="alert alert-info">
+        No download records found matching your criteria.
     </div>
+    {% endif %}
+</div>
 {% endblock %}

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'controls.j2' import pagination %}
 
 {% block web_title %}
 {{ super() }} |
@@ -151,48 +152,19 @@ Download Logs
         </table>
     </div>
 
-    <!-- Pagination -->
-    {% if total_pages > 1 %}
-    <nav aria-label="Page navigation">
-        <ul class="pagination justify-content-center">
-            {% if page > 1 %}
-            <li class="page-item">
-                <a class="page-link"
-                   href="{{ url_for('downloads.index', page=1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">First</a>
-            </li>
-            <li class="page-item">
-                <a class="page-link"
-                   href="{{ url_for('downloads.index', page=page-1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Previous</a>
-            </li>
-            {% endif %}
-
-            {% for p in range(1, total_pages + 1) %}
-            {% if p == page %}
-            <li class="page-item active">
-                <span class="page-link">{{ p }}</span>
-            </li>
-            {% elif p >= page - 2 and p <= page + 2 %}
-            <li class="page-item">
-                <a class="page-link"
-                   href="{{ url_for('downloads.index', page=p, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">{{
-                    p }}</a>
-            </li>
-            {% endif %}
-            {% endfor %}
-
-            {% if page < total_pages %}
-            <li class="page-item">
-                <a class="page-link"
-                   href="{{ url_for('downloads.index', page=page+1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Next</a>
-            </li>
-            <li class="page-item">
-                <a class="page-link"
-                   href="{{ url_for('downloads.index', page=total_pages, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Last</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
-    {% endif %}
+    {{ pagination(
+        page,
+        total_pages,
+        total,
+        items_singular='download',
+        items_plural='downloads',
+        endpoint='downloads.index',
+        start_date=start_date,
+        end_date=end_date,
+        email=email,
+        organisation=organisation,
+        download_type=download_type
+    ) }}
 
     {% else %}
     <div class="alert alert-info">

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -110,48 +110,38 @@ Download Logs
                 </td>
                 <td>
                     {% if download.download_type == 'single_record' %}
-                    {% set doi = download.doi %}
-                    {% if doi %}
-                    {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
-                    <a href="
-                                                {% if base.endswith('/catalog') %}
-                                                    {{ base }}/{{ doi }}
-                                                {% else %}
-                                                    {{ base }}/catalog/{{ doi }}
-                                                {% endif %}
-                                                " target="_blank" class="btn btn-sm btn-outline-primary">
-                        View Record
-                    </a>
-                    {% else %}
-                    -
-                    {% endif %}
+                        {% set doi = download.doi %}
+                        {% if doi %}
+                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+                            {% if base.endswith('/catalog') %}
+                                {% set url = base ~ '/' ~ doi %}
+                            {% else %}
+                                {% set url = base ~ '/catalog/' ~ doi %}
+                            {% endif %}
+                            <a href="{{ url }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
+                        {% else %}
+                            -
+                        {% endif %}
                     {% elif download.download_type == 'zip_bundle' %}
-                    {% set record_ids = download.record_ids %} {% if record_ids and record_ids|length > 0 %}
-                    {% set query_parts = [] %}
-                    {% for record_id in record_ids %}
-                    {% set _ = query_parts.append('record_id_or_doi_list=' + record_id) %}
-                    {% endfor %}
-                    {% set query = query_parts|join('&') %}
-
-                    {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
-
-                    {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
-
-                    <a href="
-                                                {% if base.endswith('/catalog') %}
-                                                    {{ base }}/subset?{{ query }}&page=1&size=50
-                                                {% else %}
-                                                    {{ base }}/catalog/subset?{{ query }}&page=1&size=50
-                                                {% endif %}
-                                                " target="_blank" class="btn btn-sm btn-outline-warning">
-                        View Bundle
-                    </a>
-
+                        {% set record_ids = download.record_ids %}
+                        {% if record_ids and record_ids|length > 0 %}
+                            {% set query_parts = [] %}
+                            {% for record_id in record_ids %}
+                                {% set _ = query_parts.append('record_id_or_doi_list=' + record_id) %}
+                            {% endfor %}
+                            {% set query = query_parts|join('&') %}
+                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+                            {% if base.endswith('/catalog') %}
+                                {% set url = base ~ '/subset?' ~ query ~ '&page=1&size=50' %}
+                            {% else %}
+                                {% set url = base ~ '/catalog/subset?' ~ query ~ '&page=1&size=50' %}
+                            {% endif %}
+                            <a href="{{ url }}" target="_blank" class="btn btn-sm btn-outline-warning">View Bundle</a>
+                        {% else %}
+                            -
+                        {% endif %}
                     {% else %}
-                    -
-                    {% endif %}
-                    {% else %}
-                    -
+                        -
                     {% endif %}
                 </td>
                 <td><small>{{ download.ip_address or '-' }}</small></td>

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -107,8 +107,7 @@
                                     {% if download.download_type == 'single_record' %}
                                         {% set doi = download.meta.get('doi', '') %}
                                         {% if doi %}
-                                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
-                                            <a href="{% if base.endswith('/catalog') %}{{ base }}/{{ doi }}{% else %}{{ base }}/catalog/{{ doi }}{% endif %}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
+                                            <a href="{{ config.MIMS_CATALOG_URL if 'catalog' in config.MIMS_CATALOG_URL else config.MIMS_CATALOG_URL.rstrip('/') + '/catalog' }}/{{ doi }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
                                         {% else %}
                                             -
                                         {% endif %}

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -1,0 +1,163 @@
+{% extends 'base.html' %}
+
+{% block web_title %}
+    {{ super() }} |
+    {% block heading %}
+        Download Logs
+    {% endblock %}
+{% endblock %}
+
+{% block content %}
+    <div class="container-fluid">
+        <h2 class="mb-4">Download Audit Logs</h2>
+
+        <!-- Filter Form -->
+        <form class="row g-3 mb-4 p-3 bg-light rounded" method="get">
+            <div class="col-md-2">
+                <label for="start_date" class="form-label">Start Date</label>
+                <input type="date" class="form-control" id="start_date" name="start_date" value="{{ start_date }}">
+            </div>
+            <div class="col-md-2">
+                <label for="end_date" class="form-label">End Date</label>
+                <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
+            </div>
+            <div class="col-md-2">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" name="email" value="{{ email }}" placeholder="user@example.com">
+            </div>
+            <div class="col-md-2">
+                <label for="organisation" class="form-label">Organisation</label>
+                <input type="text" class="form-control" id="organisation" name="organisation" value="{{ organisation }}" placeholder="Org name">
+            </div>
+            <div class="col-md-2">
+                <label for="download_type" class="form-label">Download Type</label>
+                <select class="form-control" id="download_type" name="download_type">
+                    <option value="">All Types</option>
+                    <option value="single_record" {% if download_type == 'single_record' %}selected{% endif %}>Single Record</option>
+                    <option value="zip_bundle" {% if download_type == 'zip_bundle' %}selected{% endif %}>ZIP Bundle</option>
+                </select>
+            </div>
+            <div class="col-md-2 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary w-100">Filter</button>
+            </div>
+        </form>
+
+        <!-- Action Buttons -->
+        <div class="mb-3">
+            <a href="{{ url_for('downloads.analytics') }}" class="btn btn-info">View Analytics</a>
+            <a href="{{ url_for('downloads.export_csv', start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}" class="btn btn-success">Export CSV</a>
+        </div>
+
+        <!-- Results Summary -->
+        <div class="alert alert-info">
+            Showing <strong>{{ downloads|length }}</strong> of <strong>{{ total }}</strong> total downloads
+            {% if start_date or end_date or email or organisation or download_type %}
+                <span class="ms-3">
+                    <a href="{{ url_for('downloads.index') }}" class="alert-link">Clear filters</a>
+                </span>
+            {% endif %}
+        </div>
+
+        {% if error %}
+            <div class="alert alert-danger">
+                <strong>Error:</strong> {{ error }}
+            </div>
+        {% endif %}
+
+        <!-- Downloads Table -->
+        {% if downloads %}
+            <div class="table-responsive">
+                <table class="table table-striped table-hover table-sm">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>Date/Time</th>
+                            <th>Name</th>
+                            <th>Email</th>
+                            <th>Organisation</th>
+                            <th>Type</th>
+                            <th>File Size</th>
+                            <th>Status</th>
+                            <th>IP Address</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for download in downloads %}
+                            <tr>
+                                <td>{{ download.timestamp[:19] }}</td>
+                                <td>{{ download.name or '-' }}</td>
+                                <td>{{ download.email or '-' }}</td>
+                                <td>{{ download.organisation or '-' }}</td>
+                                <td>
+                                    {% if download.download_type == 'single_record' %}
+                                        <span class="badge bg-primary">Single Record</span>
+                                    {% elif download.download_type == 'zip_bundle' %}
+                                        <span class="badge bg-warning text-dark">ZIP Bundle</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">{{ download.download_type or '-' }}</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if download.file_size %}
+                                        {{ (download.file_size / 1024 / 1024)|round(2) }} MB
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if download.success %}
+                                        <span class="badge bg-success">Success</span>
+                                    {% else %}
+                                        <span class="badge bg-danger">Failed</span>
+                                    {% endif %}
+                                </td>
+                                <td><small>{{ download.ip_address or '-' }}</small></td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Pagination -->
+            {% if total_pages > 1 %}
+                <nav aria-label="Page navigation">
+                    <ul class="pagination justify-content-center">
+                        {% if page > 1 %}
+                            <li class="page-item">
+                                <a class="page-link" href="{{ url_for('downloads.index', page=1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">First</a>
+                            </li>
+                            <li class="page-item">
+                                <a class="page-link" href="{{ url_for('downloads.index', page=page-1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Previous</a>
+                            </li>
+                        {% endif %}
+
+                        {% for p in range(1, total_pages + 1) %}
+                            {% if p == page %}
+                                <li class="page-item active">
+                                    <span class="page-link">{{ p }}</span>
+                                </li>
+                            {% elif p >= page - 2 and p <= page + 2 %}
+                                <li class="page-item">
+                                    <a class="page-link" href="{{ url_for('downloads.index', page=p, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">{{ p }}</a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+
+                        {% if page < total_pages %}
+                            <li class="page-item">
+                                <a class="page-link" href="{{ url_for('downloads.index', page=page+1, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Next</a>
+                            </li>
+                            <li class="page-item">
+                                <a class="page-link" href="{{ url_for('downloads.index', page=total_pages, start_date=start_date, end_date=end_date, email=email, organisation=organisation, download_type=download_type) }}">Last</a>
+                            </li>
+                        {% endif %}
+                    </ul>
+                </nav>
+            {% endif %}
+
+        {% else %}
+            <div class="alert alert-info">
+                No download records found matching your criteria.
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -107,7 +107,8 @@
                                     {% if download.download_type == 'single_record' %}
                                         {% set doi = download.meta.get('doi', '') %}
                                         {% if doi %}
-                                            <a href="{{ config.MIMS_CATALOG_URL if 'catalog' in config.MIMS_CATALOG_URL else config.MIMS_CATALOG_URL.rstrip('/') + '/catalog' }}/{{ doi }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
+                                            {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+                                            <a href="{% if base.endswith('/catalog') %}{{ base }}/{{ doi }}{% else %}{{ base }}/catalog/{{ doi }}{% endif %}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
                                         {% else %}
                                             -
                                         {% endif %}
@@ -119,7 +120,21 @@
                                                 {% set _ = query_parts.append('record_id_or_doi_list=' + doi) %}
                                             {% endfor %}
                                             {% set query = query_parts|join('&') %}
-                                            <a href="{{ config.MIMS_CATALOG_URL }}/subset?{{ query }}&page=1&size=50" target="_blank" class="btn btn-sm btn-outline-warning">View Bundle</a>
+
+                                                {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+
+                                                {% set base = config.get('MIMS_CATALOG_URL', '').rstrip('/') %}
+
+                                                <a href="
+                                                {% if base.endswith('/catalog') %}
+                                                    {{ base }}/subset?{{ query }}&page=1&size=50
+                                                {% else %}
+                                                    {{ base }}/catalog/subset?{{ query }}&page=1&size=50
+                                                {% endif %}
+                                                " target="_blank" class="btn btn-sm btn-outline-warning">
+                                                    View Bundle
+                                                </a>
+
                                         {% else %}
                                             -
                                         {% endif %}

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -75,8 +75,8 @@
                             <th>Email</th>
                             <th>Organisation</th>
                             <th>Type</th>
-                            <th>File Size</th>
                             <th>Status</th>
+                            <th>Record Link</th>
                             <th>IP Address</th>
                         </tr>
                     </thead>
@@ -97,17 +97,30 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% if download.file_size %}
-                                        {{ (download.file_size / 1024 / 1024)|round(2) }} MB
-                                    {% else %}
-                                        -
-                                    {% endif %}
-                                </td>
-                                <td>
                                     {% if download.success %}
                                         <span class="badge bg-success">Success</span>
                                     {% else %}
                                         <span class="badge bg-danger">Failed</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if download.download_type == 'single_record' %}
+                                        {% set doi = download.meta.get('doi', '') %}
+                                        {% if doi %}
+                                            <a href="http://mims.localhost:2021/catalog/{{ doi }}" target="_blank" class="btn btn-sm btn-outline-primary">View Record</a>
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    {% elif download.download_type == 'zip_bundle' %}
+                                        {% set dois = download.meta.get('dois', []) %}
+                                        {% if dois and dois|length > 0 %}
+                                            {% set query = '&'.join(['record_id_or_doi_list=' + doi for doi in dois]) %}
+                                            <a href="http://mims.localhost:2021/catalog/subset?{{ query }}&page=1&size=50" target="_blank" class="btn btn-sm btn-outline-warning">View Bundle</a>
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    {% else %}
+                                        -
                                     {% endif %}
                                 </td>
                                 <td><small>{{ download.ip_address or '-' }}</small></td>

--- a/odp/ui/admin/templates/download_index.html
+++ b/odp/ui/admin/templates/download_index.html
@@ -114,7 +114,11 @@
                                     {% elif download.download_type == 'zip_bundle' %}
                                         {% set dois = download.meta.get('dois', []) %}
                                         {% if dois and dois|length > 0 %}
-                                            {% set query = '&'.join(['record_id_or_doi_list=' + doi for doi in dois]) %}
+                                            {% set query_parts = [] %}
+                                            {% for doi in dois %}
+                                                {% set _ = query_parts.append('record_id_or_doi_list=' + doi) %}
+                                            {% endfor %}
+                                            {% set query = query_parts|join('&') %}
                                             <a href="http://mims.localhost:2021/catalog/subset?{{ query }}&page=1&size=50" target="_blank" class="btn btn-sm btn-outline-warning">View Bundle</a>
                                         {% else %}
                                             -

--- a/odp/ui/admin/templates/record_edit.html
+++ b/odp/ui/admin/templates/record_edit.html
@@ -24,22 +24,10 @@
 {% block scripts %}
     {{ super() }}
     <script>
-        function showErrorMessage(message) {
-            const alertDiv = document.createElement('div');
-            alertDiv.className = 'alert alert-danger alert-dismissible fade show';
-            alertDiv.setAttribute('role', 'alert');
-            alertDiv.innerHTML = `
-                ${message}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            `;
-            const container = document.querySelector('main') || document.body;
-            container.insertBefore(alertDiv, container.firstChild);
-        }
-
         $(function() {
             $("#new-doi").bind("click", function() {
                 if (!$("#collection_id").val()) {
-                    showErrorMessage("Please select a collection.");
+                    alert("Please select a collection.");
                     return;
                 }
                 $.getJSON(rootPath + "/collections/" + $("#collection_id").val() + "/doi/new",
@@ -47,7 +35,7 @@
                         if (result.doi) {
                             $("#doi").val(result.doi);
                         } else if (result.detail) {
-                            showErrorMessage(result.detail);
+                            alert(result.detail);
                         }
                     }
                 );

--- a/odp/ui/admin/templates/record_edit.html
+++ b/odp/ui/admin/templates/record_edit.html
@@ -24,10 +24,22 @@
 {% block scripts %}
     {{ super() }}
     <script>
+        function showErrorMessage(message) {
+            const alertDiv = document.createElement('div');
+            alertDiv.className = 'alert alert-danger alert-dismissible fade show';
+            alertDiv.setAttribute('role', 'alert');
+            alertDiv.innerHTML = `
+                ${message}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            `;
+            const container = document.querySelector('main') || document.body;
+            container.insertBefore(alertDiv, container.firstChild);
+        }
+
         $(function() {
             $("#new-doi").bind("click", function() {
                 if (!$("#collection_id").val()) {
-                    alert("Please select a collection.");
+                    showErrorMessage("Please select a collection.");
                     return;
                 }
                 $.getJSON(rootPath + "/collections/" + $("#collection_id").val() + "/doi/new",
@@ -35,7 +47,7 @@
                         if (result.doi) {
                             $("#doi").val(result.doi);
                         } else if (result.detail) {
-                            alert(result.detail);
+                            showErrorMessage(result.detail);
                         }
                     }
                 );

--- a/odp/ui/admin/views/__init__.py
+++ b/odp/ui/admin/views/__init__.py
@@ -2,12 +2,13 @@ from flask import Flask
 
 
 def init_app(app: Flask):
-    from . import catalogs, clients, collections, home, providers, records, roles, schemas, tags, users, vocabularies
+    from . import catalogs, clients, collections, downloads, home, providers, records, roles, schemas, tags, users, vocabularies
 
     app.register_blueprint(home.bp)
     app.register_blueprint(catalogs.bp, url_prefix='/catalogs')
     app.register_blueprint(clients.bp, url_prefix='/clients')
     app.register_blueprint(collections.bp, url_prefix='/collections')
+    app.register_blueprint(downloads.bp, url_prefix='/downloads')
     app.register_blueprint(providers.bp, url_prefix='/providers')
     app.register_blueprint(records.bp, url_prefix='/records')
     app.register_blueprint(roles.bp, url_prefix='/roles')

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -136,7 +136,7 @@ def export_csv():
     try:
 
         api_url = f"{api.api_url}/download/export/csv"
-        response = api._send_request('GET', api_url, data=None, params=params)
+        response = api._send_request('GET', api_url, data=None, files=None, params=params, headers={}, stream=True)
 
         # Check for errors (this will raise ODPAPIError if the backend fails)
         response.raise_for_status()

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -1,0 +1,153 @@
+"""Admin interface for download audit logs and reporting."""
+from datetime import datetime, timedelta
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+import requests
+from urllib.parse import urlencode
+
+bp = Blueprint('downloads', __name__)
+
+
+def get_api_base_url():
+    """Get the base URL for API calls (assuming local backend)."""
+    return 'http://localhost:8000'
+
+
+@bp.route('/')
+def index():
+    """Display paginated download logs with filtering options."""
+    page = request.args.get('page', 1, type=int)
+    start_date = request.args.get('start_date', '')
+    end_date = request.args.get('end_date', '')
+    email = request.args.get('email', '')
+    organisation = request.args.get('organisation', '')
+    download_type = request.args.get('download_type', '')
+
+    # Build query parameters
+    params = {
+        'page': page,
+        'size': 50,
+    }
+
+    if start_date:
+        params['start_date'] = start_date
+    if end_date:
+        params['end_date'] = end_date
+    if email:
+        params['email'] = email
+    if organisation:
+        params['organisation'] = organisation
+    if download_type:
+        params['download_type'] = download_type
+
+    try:
+        # Call the backend API
+        api_url = f"{get_api_base_url()}/download/logs"
+        response = requests.get(api_url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        return render_template(
+            'download_index.html',
+            downloads=data.get('items', []),
+            total=data.get('total', 0),
+            page=page,
+            total_pages=data.get('total_pages', 0),
+            size=data.get('size', 50),
+            start_date=start_date,
+            end_date=end_date,
+            email=email,
+            organisation=organisation,
+            download_type=download_type,
+        )
+
+    except requests.RequestException as e:
+        flash(f'Error retrieving download logs: {str(e)}', category='error')
+        return render_template(
+            'download_index.html',
+            downloads=[],
+            total=0,
+            page=1,
+            total_pages=0,
+            size=50,
+            error=str(e),
+        )
+
+
+@bp.route('/analytics')
+def analytics():
+    """Display download analytics and statistics dashboard."""
+    start_date = request.args.get('start_date', '')
+    end_date = request.args.get('end_date', '')
+
+    # Default to last 30 days if not specified
+    if not end_date:
+        end_date = datetime.now().strftime('%Y-%m-%d')
+    if not start_date:
+        start_date = (datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d')
+
+    params = {}
+    if start_date:
+        params['start_date'] = start_date
+    if end_date:
+        params['end_date'] = end_date
+
+    try:
+        # Call the backend API for statistics
+        api_url = f"{get_api_base_url()}/download/stats"
+        response = requests.get(api_url, params=params, timeout=10)
+        response.raise_for_status()
+        stats = response.json()
+
+        return render_template(
+            'download_analytics.html',
+            stats=stats,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    except requests.RequestException as e:
+        flash(f'Error retrieving download statistics: {str(e)}', category='error')
+        return render_template(
+            'download_analytics.html',
+            stats={},
+            error=str(e),
+        )
+
+
+@bp.route('/export')
+def export_csv():
+    """Export download logs as CSV."""
+    start_date = request.args.get('start_date', '')
+    end_date = request.args.get('end_date', '')
+    email = request.args.get('email', '')
+    organisation = request.args.get('organisation', '')
+    download_type = request.args.get('download_type', '')
+
+    # Build query parameters
+    params = {}
+    if start_date:
+        params['start_date'] = start_date
+    if end_date:
+        params['end_date'] = end_date
+    if email:
+        params['email'] = email
+    if organisation:
+        params['organisation'] = organisation
+    if download_type:
+        params['download_type'] = download_type
+
+    try:
+        # Call the backend API
+        api_url = f"{get_api_base_url()}/download/export/csv"
+        response = requests.get(api_url, params=params, timeout=30)
+        response.raise_for_status()
+
+        # The response should already be a CSV with proper headers
+        return response.content, 200, {
+            'Content-Disposition': f'attachment; filename="download_logs.csv"',
+            'Content-Type': 'text/csv',
+        }
+
+    except requests.RequestException as e:
+        flash(f'Error exporting download logs: {str(e)}', category='error')
+        return redirect(request.referrer or url_for('.index'))

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -1,4 +1,5 @@
 """Admin interface for download audit logs and reporting."""
+import os
 from datetime import datetime, timedelta
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 import requests
@@ -8,8 +9,8 @@ bp = Blueprint('downloads', __name__)
 
 
 def get_api_base_url():
-    """Get the base URL for API calls (assuming local backend)."""
-    return 'http://localhost:8000'
+    """Get the base URL for API calls from environment variable or use default."""
+    return os.getenv('ODP_API_URL', 'http://localhost:2020')
 
 
 @bp.route('/')

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -1,16 +1,12 @@
 """Admin interface for download audit logs and reporting."""
-import os
 from datetime import datetime, timedelta
-from flask import Blueprint, render_template, request, redirect, url_for, flash
+
 import requests
-from urllib.parse import urlencode
+from flask import Blueprint, Response, render_template, request, redirect, url_for, flash
+
+from odp.ui.base import api
 
 bp = Blueprint('downloads', __name__)
-
-
-def get_api_base_url():
-    """Get the base URL for API calls from environment variable or use default."""
-    return os.getenv('ODP_API_URL', 'http://localhost:2020')
 
 
 @bp.route('/')
@@ -41,19 +37,16 @@ def index():
         params['download_type'] = download_type
 
     try:
-        # Call the backend API
-        api_url = f"{get_api_base_url()}/download/logs"
-        response = requests.get(api_url, params=params, timeout=10)
-        response.raise_for_status()
-        data = response.json()
+
+        download_logs = api.get('/download/logs', params=params)
 
         return render_template(
             'download_index.html',
-            downloads=data.get('items', []),
-            total=data.get('total', 0),
+            downloads=download_logs.get('items', []),
+            total=download_logs.get('total', 0),
             page=page,
-            total_pages=data.get('total_pages', 0),
-            size=data.get('size', 50),
+            total_pages=download_logs.get('total_pages', 0),
+            size=download_logs.get('size', 50),
             start_date=start_date,
             end_date=end_date,
             email=email,
@@ -94,14 +87,11 @@ def analytics():
 
     try:
         # Call the backend API for statistics
-        api_url = f"{get_api_base_url()}/download/stats"
-        response = requests.get(api_url, params=params, timeout=10)
-        response.raise_for_status()
-        stats = response.json()
+        download_stats = api.get('/download/stats', params=params)
 
         return render_template(
             'download_analytics.html',
-            stats=stats,
+            stats=download_stats,
             start_date=start_date,
             end_date=end_date,
         )
@@ -138,17 +128,25 @@ def export_csv():
         params['download_type'] = download_type
 
     try:
-        # Call the backend API
-        api_url = f"{get_api_base_url()}/download/export/csv"
-        response = requests.get(api_url, params=params, timeout=30)
+
+        api_url = f"{api.api_url}/download/export/csv"
+        response = api._send_request('GET', api_url, data=None, params=params)
+
+        # Check for errors (this will raise ODPAPIError if the backend fails)
         response.raise_for_status()
 
-        # The response should already be a CSV with proper headers
-        return response.content, 200, {
-            'Content-Disposition': f'attachment; filename="download_logs.csv"',
-            'Content-Type': 'text/csv',
-        }
+        # Stream the CSV content directly to the browser
+        return Response(
+            response.iter_content(chunk_size=1024),
+            content_type=response.headers.get('Content-Type', 'text/csv'),
+            headers={
+                'Content-Disposition': response.headers.get(
+                    'Content-Disposition',
+                    'attachment; filename="download_logs.csv"'
+                )
+            }
+        )
 
-    except requests.RequestException as e:
+    except Exception as e:
         flash(f'Error exporting download logs: {str(e)}', category='error')
         return redirect(request.referrer or url_for('.index'))

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -47,7 +47,7 @@ def index():
             downloads=download_logs.get('items', []),
             total=download_logs.get('total', 0),
             page=page,
-            total_pages=download_logs.get('total_pages', 0),
+            total_pages=download_logs.get('pages', 0),
             size=download_logs.get('size', 50),
             start_date=start_date,
             end_date=end_date,

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -1,10 +1,10 @@
 """Admin interface for download audit logs and reporting."""
 from datetime import datetime, timedelta
 
-import requests
 from flask import Blueprint, Response, render_template, request, redirect, url_for, flash
 
 from odp.const import ODPScope
+from odp.lib.client import ODPAPIError
 from odp.ui.base import api
 
 bp = Blueprint('downloads', __name__)
@@ -40,7 +40,7 @@ def index():
 
     try:
 
-        download_logs = api.get('/download/logs', params=params)
+        download_logs = api.get('/download/logs', **params)
 
         return render_template(
             'download_index.html',
@@ -56,8 +56,8 @@ def index():
             download_type=download_type,
         )
 
-    except requests.RequestException as e:
-        flash(f'Error retrieving download logs: {str(e)}', category='error')
+    except ODPAPIError as e:
+        flash(f'Error retrieving download logs: {e.error_detail}', category='error')
         return render_template(
             'download_index.html',
             downloads=[],
@@ -90,8 +90,7 @@ def analytics():
 
     try:
         # Call the backend API for statistics
-        download_stats = api.get('/download/stats', params=params)
-
+        download_stats = api.get('/download/stats', **params)
 
         return render_template(
             'download_analytics.html',
@@ -100,9 +99,8 @@ def analytics():
             end_date=end_date,
         )
 
-
-    except requests.RequestException as e:
-        flash(f'Error retrieving download statistics: {str(e)}', category='error')
+    except ODPAPIError as e:
+        flash(f'Error retrieving download statistics: {e.error_detail}', category='error')
         return render_template(
             'download_analytics.html',
             stats={},
@@ -135,11 +133,7 @@ def export_csv():
 
     try:
 
-        api_url = f"{api.api_url}/download/export/csv"
-        response = api._send_request('GET', api_url, data=None, files=None, params=params, headers={}, stream=True)
-
-        # Check for errors (this will raise ODPAPIError if the backend fails)
-        response.raise_for_status()
+        response = api.request('GET', '/download/export/csv', stream=True, **params)
 
         # Stream the CSV content directly to the browser
         return Response(

--- a/odp/ui/admin/views/downloads.py
+++ b/odp/ui/admin/views/downloads.py
@@ -4,12 +4,14 @@ from datetime import datetime, timedelta
 import requests
 from flask import Blueprint, Response, render_template, request, redirect, url_for, flash
 
+from odp.const import ODPScope
 from odp.ui.base import api
 
 bp = Blueprint('downloads', __name__)
 
 
 @bp.route('/')
+@api.view(ODPScope.CATALOG_READ)
 def index():
     """Display paginated download logs with filtering options."""
     page = request.args.get('page', 1, type=int)
@@ -68,6 +70,7 @@ def index():
 
 
 @bp.route('/analytics')
+@api.view(ODPScope.CATALOG_READ)
 def analytics():
     """Display download analytics and statistics dashboard."""
     start_date = request.args.get('start_date', '')
@@ -89,12 +92,14 @@ def analytics():
         # Call the backend API for statistics
         download_stats = api.get('/download/stats', params=params)
 
+
         return render_template(
             'download_analytics.html',
             stats=download_stats,
             start_date=start_date,
             end_date=end_date,
         )
+
 
     except requests.RequestException as e:
         flash(f'Error retrieving download statistics: {str(e)}', category='error')
@@ -106,6 +111,7 @@ def analytics():
 
 
 @bp.route('/export')
+@api.view(ODPScope.CATALOG_READ)
 def export_csv():
     """Export download logs as CSV."""
     start_date = request.args.get('start_date', '')


### PR DESCRIPTION
Added a download audit reporting page to the admin UI showing a filterable log of all downloads by date, email, organisation, and type. Includes an analytics dashboard with aggregate statistics and a CSV export. Record and bundle links in the log now point to the correct MIMS catalog URLs using the MIMS_CATALOG_URL environment variable instead of hardcoded values. Fixed API call conventions, exception handling, and added the catalog:read scope to authorised requests.
